### PR TITLE
Update README.rst and search for kitty pid in theme config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,12 +98,23 @@ Configuration
 
        '''A config module for the Kitty Theme Changer Tool.'''
        from pathlib import Path
+       from os import getpid
+       from psutil import process_iter
+       
        theme_dir = Path('~/kitty-themes/themes').expanduser()
        conf_dir = Path('~/.config/kitty').expanduser()
        theme_link = conf_dir.joinpath('theme.conf')
        light_theme_link = conf_dir.joinpath('light-theme.conf')
        dark_theme_link = conf_dir.joinpath('dark-theme.conf')
-       socket = 'unix:/tmp/kittysocket'
+       
+       def kitty_pid():
+         ps = {x.pid: x for x in psutil.process_iter(['name', 'pid', 'ppid'])}
+         cp = ps[getpid()]
+         while cp.name() != 'kitty':
+            cp = cp.parent()
+         return cp.pid
+
+       socket = 'unix:/tmp/kitty-socket-{}'.format(kitty_pid())
 
 Tips and Tricks
 ===============
@@ -144,7 +155,7 @@ work correctly.
 - Kitty Socket: Any launchers or aliases that you use to start kitty should
   include a "--listen-on" option. The socket string that you choose for the
   "--listen-on" flag should match the socket string in your Kitty Theme Changer
-  configuration file.
+  configuration file. You can also use "listen_on unix:/tmp/kitty-socket" in kitty.conf
 
 - Single Instance/Instance Groups: For the "--live" feature to change the color
   theme for all running windows it is useful to run kitty with the


### PR DESCRIPTION
Add function that searches for kitty term pid in theme changer config, so proper socket file can be located (socket  file is `listen_on` argument concatenated with "-PID".